### PR TITLE
Fix: optimized schedule generation with pin-aware filtering

### DIFF
--- a/assets/js/schedule/course_schedule.js
+++ b/assets/js/schedule/course_schedule.js
@@ -133,7 +133,7 @@ class CourseSchedule {
         );
     }
 
-    static async generateAllAvailableSchedules(courses, unavailableSlots = [], cancellationToken = null, progressCallback = null) {
+    static async generateAllAvailableSchedules(courses, unavailableSlots = [], pinnedCRNs = new Set(), cancellationToken = null, progressCallback = null) {
         const allSchedules = [];
         
         // Filter out courses that don't have lessons or have empty lessons array
@@ -180,6 +180,12 @@ class CourseSchedule {
             // Filter out lessons without valid day/time
             let validLessons = lessons.filter(lesson => CourseSchedule._isValidLesson(lesson, unavailableSlots));
             
+            // Possible Bug fix ig
+            const pinnedLessonInCourse = validLessons.find(lesson => pinnedCRNs.has(lesson.crn));
+            if (pinnedLessonInCourse) {
+                validLessons = [pinnedLessonInCourse];
+            }
+
             // Filter by instructor if specified
             if (selectedInstructor) {
                 validLessons = validLessons.filter(lesson => lesson.instructor === selectedInstructor);

--- a/assets/js/schedule/course_schedule.js
+++ b/assets/js/schedule/course_schedule.js
@@ -180,7 +180,7 @@ class CourseSchedule {
             // Filter out lessons without valid day/time
             let validLessons = lessons.filter(lesson => CourseSchedule._isValidLesson(lesson, unavailableSlots));
             
-            // Possible Bug fix ig
+            // Filter out non-pinned lessons if any pinned lessons exist for this course
             const pinnedLessonInCourse = validLessons.find(lesson => pinnedCRNs.has(lesson.crn));
             if (pinnedLessonInCourse) {
                 validLessons = [pinnedLessonInCourse];

--- a/assets/js/schedule/managers/schedule_state_manager.js
+++ b/assets/js/schedule/managers/schedule_state_manager.js
@@ -45,8 +45,8 @@ class ScheduleStateManager {
             const schedules = await CourseSchedule.generateAllAvailableSchedules(
                 courses,
                 unavailableSlots,
-                this.cancellationToken,
                 this.pinnedLessons,
+                this.cancellationToken,
                 (count, validCount) => LoadingOverlayManager.updateCounter(count, validCount)
             );
             

--- a/assets/js/schedule/managers/schedule_state_manager.js
+++ b/assets/js/schedule/managers/schedule_state_manager.js
@@ -46,6 +46,7 @@ class ScheduleStateManager {
                 courses,
                 unavailableSlots,
                 this.cancellationToken,
+                this.pinnedLessons,
                 (count, validCount) => LoadingOverlayManager.updateCounter(count, validCount)
             );
             


### PR DESCRIPTION
The current schedule generation algorithm has a hard limit of 1000 combinations. When multiple courses are pinned, the search space becomes too large, often resulting in 0 valid plans found within the limit.

What i did:
Updated `CourseSchedule.generateAllAvailableSchedules` to be pin-aware. It now uses the `pinnedCRNs` to filter course sections early in the recursive loop, drastically reducing the search space and ensuring pinned sections are always included in the results