### PR TITLE
Fix horizontal scroll overflow on hover

### DIFF
--- a/assets/js/schedule/utils/schedule_style.js
+++ b/assets/js/schedule/utils/schedule_style.js
@@ -97,8 +97,8 @@ class ScheduleStyle {
         
         // Transform scales
         scale: {
-            default: 'scale(1)',
-            hover: 'scale(1.02)'
+            default: 'translateY(0)',
+            hover: 'translateY(-5px)'
         },
         
         // Opacity values


### PR DESCRIPTION
The scale(1.02) animation was causing the container to overflow on the x-axis, triggering a scrollbar at bottom.

I changed the hover effect to translateY(-5px). This creates a lift effect without changing the element's width, preventing the layout shift and scrollbar issue.